### PR TITLE
OT184-79 Endpoint para listar comentarios en base a un post

### DIFF
--- a/src/main/java/com/alkemy/ong/data/gateways/DefaultCommentGateway.java
+++ b/src/main/java/com/alkemy/ong/data/gateways/DefaultCommentGateway.java
@@ -46,11 +46,6 @@ public class DefaultCommentGateway implements CommentGateway {
         commentRepository.deleteById(id);
     }
 
-    @Override
-    public List<Comment> findAllByNewsId(Long id) {
-        return commentRepository.findAllByNewsId(String.valueOf(id)).stream().map(this::toModel).collect(toList());
-    }
-
     private UserEntity getUserEntity(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(
@@ -65,6 +60,10 @@ public class DefaultCommentGateway implements CommentGateway {
                 );
     }
 
+    @Override
+    public List<Comment> findAllByNewsId(Long id) {
+        return commentRepository.findAllByNewsId(String.valueOf(id)).stream().map(this::toModel).collect(toList());
+    }
 
     private CommentEntity toEntity(Comment comment) {
         return CommentEntity.builder()

--- a/src/main/java/com/alkemy/ong/data/gateways/DefaultCommentGateway.java
+++ b/src/main/java/com/alkemy/ong/data/gateways/DefaultCommentGateway.java
@@ -62,7 +62,10 @@ public class DefaultCommentGateway implements CommentGateway {
 
     @Override
     public List<Comment> findAllByNewsId(Long id) {
-        return commentRepository.findAllByNewsId(String.valueOf(id)).stream().map(this::toModel).collect(toList());
+        return commentRepository.findAllByNewsId(this.getNewsEntity(id))
+                .stream()
+                .map(this::toModel)
+                .collect(toList());
     }
 
     private CommentEntity toEntity(Comment comment) {

--- a/src/main/java/com/alkemy/ong/data/gateways/DefaultCommentGateway.java
+++ b/src/main/java/com/alkemy/ong/data/gateways/DefaultCommentGateway.java
@@ -56,7 +56,7 @@ public class DefaultCommentGateway implements CommentGateway {
     private NewsEntity getNewsEntity(Long newsId) {
         return newsRepository.findById(newsId)
                 .orElseThrow(
-                        () -> new ResourceNotFoundException("News with id: " + newsId + " not found.")
+                        () -> new ResourceNotFoundException("News with id: " + newsId)
                 );
     }
 

--- a/src/main/java/com/alkemy/ong/data/gateways/DefaultCommentGateway.java
+++ b/src/main/java/com/alkemy/ong/data/gateways/DefaultCommentGateway.java
@@ -13,7 +13,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.toList;
 
@@ -45,6 +44,11 @@ public class DefaultCommentGateway implements CommentGateway {
     public void delete(Long id) {
         commentRepository.findById(id).orElseThrow(() -> new ResourceNotFoundException("Not found Id"));
         commentRepository.deleteById(id);
+    }
+
+    @Override
+    public List<Comment> findAllByNewsId(Long id) {
+        return commentRepository.findAllByNewsId(String.valueOf(id)).stream().map(this::toModel).collect(toList());
     }
 
     private UserEntity getUserEntity(Long userId) {

--- a/src/main/java/com/alkemy/ong/data/repositories/CommentRepository.java
+++ b/src/main/java/com/alkemy/ong/data/repositories/CommentRepository.java
@@ -2,8 +2,13 @@ package com.alkemy.ong.data.repositories;
 
 import com.alkemy.ong.data.entities.CommentEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
+    @Query(nativeQuery = true, value ="SELECT * FROM comments WHERE news_id = :id")
+    List<CommentEntity> findAllByNewsId(String id);
 }

--- a/src/main/java/com/alkemy/ong/data/repositories/CommentRepository.java
+++ b/src/main/java/com/alkemy/ong/data/repositories/CommentRepository.java
@@ -1,14 +1,13 @@
 package com.alkemy.ong.data.repositories;
 
 import com.alkemy.ong.data.entities.CommentEntity;
+import com.alkemy.ong.data.entities.NewsEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
-    @Query(nativeQuery = true, value ="SELECT * FROM comments WHERE news_id = :id")
-    List<CommentEntity> findAllByNewsId(String id);
+    List<CommentEntity> findAllByNewsId(NewsEntity entity);
 }

--- a/src/main/java/com/alkemy/ong/domain/comments/CommentGateway.java
+++ b/src/main/java/com/alkemy/ong/domain/comments/CommentGateway.java
@@ -9,4 +9,6 @@ public interface CommentGateway {
     Comment create(Comment comment);
 
     void delete(Long id);
+
+    List<Comment> findAllByNewsId(Long id);
 }

--- a/src/main/java/com/alkemy/ong/domain/comments/CommentService.java
+++ b/src/main/java/com/alkemy/ong/domain/comments/CommentService.java
@@ -24,4 +24,8 @@ public class CommentService {
     public void delete(Long id) {
         commentGateway.delete(id);
     }
+
+    public List<Comment> findAllByNewsId(Long id) {
+        return commentGateway.findAllByNewsId(id);
+    }
 }

--- a/src/main/java/com/alkemy/ong/web/controllers/NewsController.java
+++ b/src/main/java/com/alkemy/ong/web/controllers/NewsController.java
@@ -1,5 +1,7 @@
 package com.alkemy.ong.web.controllers;
 
+import com.alkemy.ong.domain.comments.Comment;
+import com.alkemy.ong.domain.comments.CommentService;
 import com.alkemy.ong.domain.news.News;
 import com.alkemy.ong.domain.news.NewsService;
 import com.alkemy.ong.domain.utils.PageModel;
@@ -12,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
+import java.util.List;
 
 import static java.util.stream.Collectors.toList;
 
@@ -21,8 +24,10 @@ import static java.util.stream.Collectors.toList;
 public class NewsController {
 
     private final NewsService newsService;
-    public NewsController(NewsService newsService){
+    private final CommentService commentService;
+    public NewsController(NewsService newsService, CommentService commentService){
         this.newsService = newsService;
+        this.commentService = commentService;
     }
 
     @GetMapping("/{id}")
@@ -60,6 +65,20 @@ public class NewsController {
     @PutMapping("/{id}")
     public ResponseEntity<NewsDTO> update(@PathVariable Long id,@Valid @RequestBody NewsDTO newsDTO){
         return ResponseEntity.ok().body(toDTO(newsService.update(this.toModel(newsDTO),id)));
+    }
+
+    @GetMapping("/{id}/comments")
+    public ResponseEntity<List<CommentController.CommentDTO>> findAllByNewsId(@PathVariable Long id){
+        return ResponseEntity.ok().body(commentService.findAllByNewsId(id).stream().map(this::toDto).collect(toList()));
+    }
+
+    private CommentController.CommentDTO toDto(Comment comment) {
+        return CommentController.CommentDTO.builder()
+                .id(comment.getId())
+                .userId(comment.getUserId())
+                .body(comment.getBody())
+                .newsId(comment.getNewsId())
+                .build();
     }
 
     @Data

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,7 +8,6 @@ spring:
     continue-on-error: true
   application:
     pageSize: 10
-
 loggin:
   level:
     com:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -6,7 +6,8 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     initialization-mode: always
     continue-on-error: true
-
+  application:
+    pageSize: 10
 
 loggin:
   level:
@@ -16,8 +17,7 @@ loggin:
           InstanceMetadataServiceResourceFetcher: error
         util:
           EC2MetadataUtils: error
-  application:
-    pageSize: 10
+
 
 amazonProperties:
   endpointUrl: ${AMAZON_S3_ENDPOINT_URL}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -151,3 +151,6 @@ INSERT INTO contacts (name, phone, email, message, is_deleted, created_at,update
     VALUES('name 2', '2222222222', 'email2@contact.com', "message 2",0,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP);
 INSERT INTO contacts (name, phone, email, message, is_deleted, created_at,updated_at)
     VALUES('name 3', '3333333333', 'email3@contact.com', "message 3",0,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP);
+
+INSERT INTO users (first_name, last_name, email, password, photo, is_deleted,created_at,updated_at)
+    VALUES('first_name', 'last_name', 'email@email.com', 'password', '/photo.jpg',0,CURRENT_TIMESTAMP,CURRENT_TIMESTAMP);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -145,3 +145,18 @@ CREATE TABLE contacts (
    updated_at timestamp NULL NOT NULL,
    CONSTRAINT pk_contacts PRIMARY KEY (id)
 );
+
+CREATE TABLE comments (
+  id BIGINT AUTO_INCREMENT NOT NULL,
+   user_id BIGINT NOT NULL,
+   body VARCHAR(255) NOT NULL,
+   news_id BIGINT NOT NULL,
+   created_at datetime NOT NULL,
+   updated_at datetime NOT NULL,
+   is_deleted BIT(1) NOT NULL,
+   CONSTRAINT pk_comments PRIMARY KEY (id)
+);
+
+ALTER TABLE comments ADD CONSTRAINT FK_COMMENTS_ON_NEWS FOREIGN KEY (news_id) REFERENCES news (id);
+
+ALTER TABLE comments ADD CONSTRAINT FK_COMMENTS_ON_USER FOREIGN KEY (user_id) REFERENCES users (id);


### PR DESCRIPTION
**Ticket OT184-79:** Endpoint para listar comentarios en base a un post

</br>


**SUMMARY:**
* Created findAllByNewsId method in NewsController, CommentService, CommentGateway and DefaultCommentGateway
* Created builder method in NewsController, for CommentDTO
* Added "create table" script for comments
* Added seed data for users

</br>


**EVIDENCE**

**Method:** POST
**Path:** /news/:id/comments


**Database:** 
![image](https://user-images.githubusercontent.com/75321699/165496632-c1d3a02d-8bf6-4001-821a-1c52728db945.png)

**Succesfull Case:** 200 OK
![image](https://user-images.githubusercontent.com/75321699/165496698-0e497a1c-93eb-41d7-9dba-d152e5b5efdf.png)

**Error Case:** 404 Not Found
![image](https://user-images.githubusercontent.com/75321699/165602879-551972f1-3adc-44c5-9cb2-85ebd66c35e1.png)